### PR TITLE
fix: download Electron binary on install so `pnpm dev` works on a clean clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A local-first Electron app for running independent AI coworkers. Each coworker h
 
 ## Quick start
 
-Requires **Node.js 22+** and **pnpm**.
+Requires **Node.js 22.12+** and **pnpm**.
 
 ```sh
 pnpm install

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
   "license": "UNLICENSED",
   "private": true,
   "packageManager": "pnpm@11.18.0",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "node scripts/dev-app-name.js && electron-vite dev",
-    "postinstall": "node scripts/dev-app-name.js",
+    "postinstall": "install-electron && node scripts/dev-app-name.js",
     "build": "pnpm typecheck && electron-vite build",
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json",


### PR DESCRIPTION
## Problem

`pnpm dev` fails on a clean clone:

```
dev server running for the electron renderer process at:
  ➜  Local:   http://localhost:5173/

error during start dev server and electron app:
Error: Electron uninstall
    at getElectronPath (.../electron-vite/dist/chunks/lib-q6ns0vZr.js:155:19)
```

Both build steps succeed — main process and preload bundle fine, the renderer dev server comes up — and then the app never launches, because there is no Electron binary in `node_modules`.

## Cause

[Electron 42 removed the `postinstall` script that downloaded the binary](https://github.com/electron/electron/blob/main/docs/breaking-changes.md), as supply-chain hardening so the package can be installed with `--ignore-scripts`. `electron@43.4.1` declares no `scripts` at all; it ships an `install-electron` bin, and the binary is fetched either by that script or on demand the first time electron's own bin script runs.

`electron-vite` resolves the binary path directly (reads `path.txt` and checks `dist/`) rather than going through electron's bin, so the on-demand download never triggers and it throws `Electron uninstall`.

Worth noting for anyone who hits this: the `allowBuilds` list in `pnpm-workspace.yaml` is *not* involved. It looks like the culprit, but adding `electron: true` there changes nothing — there is no build script left to allow. That list is fine as-is.

## Fix

Chain `install-electron` into `postinstall` so one `pnpm install` leaves the checkout runnable. The script exits early when the binary is already present, so repeat installs stay cheap.

Also added an `engines` field. `electron@43` requires `>=22.12.0` and `src/main/db/database.ts` uses the built-in `node:sqlite`, so declaring the floor fails fast instead of failing obscurely later. README updated to match (22+ → 22.12+).

## Why CI didn't catch it

`.github/workflows/evals.yml` runs only `pnpm eval:report:contract`. That runs `pnpm build` (typecheck + `electron-vite build`), which never launches Electron — so a missing binary is invisible to CI. Nothing in CI runs the app.

## Verification

Reproduced and fixed against clean clones, not just an existing checkout:

- Fresh clone on `main` → `pnpm install` → no `dist/` directory, `pnpm dev` fails as above.
- Fresh clone on this branch → `pnpm install` → `install-electron` runs, `Electron.app` present, `path.txt` written, and the exact resolution `electron-vite` performs succeeds:

```
RESOLVES OK -> .../electron/dist/Electron.app/Contents/MacOS/Electron
```

- `pnpm typecheck` passes.
- App launches and runs; the only runtime log entries are the expected `Configure OpenRouter in Settings first` from the unconfigured-provider path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132hEBSeVpPb45yxZsXx2Y4