### PR TITLE
Fix artifact open/download, and show created files as cards in the chat

### DIFF
--- a/src/main/integrations/artifact-files.ts
+++ b/src/main/integrations/artifact-files.ts
@@ -1,5 +1,5 @@
 import { stat, unlink } from "node:fs/promises";
-import { relative } from "node:path";
+import { relative, sep } from "node:path";
 import type { Artifact } from "@shared/contracts";
 import type { CoworkerDatabase } from "@main/db/database";
 import { resolveWorkspacePath } from "@main/tools/workspace-path";
@@ -9,13 +9,38 @@ export interface ResolvedArtifactFile {
   path: string;
 }
 
+const caseInsensitiveFilesystem =
+  process.platform === "darwin" || process.platform === "win32";
+
+function escapesRoot(path: string): boolean {
+  return path === ".." || path.startsWith(`..${sep}`);
+}
+
+/**
+ * Recorded artifact paths are absolute, and their workspace root may have been
+ * spelled with different casing than the one stored on the coworker (macOS and
+ * Windows resolve `…/Coworker` and `…/coworker` to the same directory). Compare
+ * case-insensitively on those platforms so a file inside the workspace is still
+ * recognised, keeping the original casing of the tail segments.
+ */
+export function workspaceRelativePath(workspaceRoot: string, filePath: string): string {
+  const direct = relative(workspaceRoot, filePath);
+  if (!escapesRoot(direct) || !caseInsensitiveFilesystem) return direct;
+
+  const insensitive = relative(workspaceRoot.toLowerCase(), filePath.toLowerCase());
+  if (escapesRoot(insensitive)) return direct;
+
+  const segments = filePath.split(sep);
+  return segments.slice(segments.length - insensitive.split(sep).length).join(sep);
+}
+
 export async function resolveArtifactFile(
   database: CoworkerDatabase,
   artifactId: string,
 ): Promise<ResolvedArtifactFile> {
   const artifact = database.getArtifact(artifactId);
   const coworker = database.getCoworker(artifact.coworkerId);
-  const workspacePath = relative(coworker.workspacePath, artifact.filePath) || ".";
+  const workspacePath = workspaceRelativePath(coworker.workspacePath, artifact.filePath) || ".";
   const path = await resolveWorkspacePath(coworker.workspacePath, workspacePath);
   const details = await stat(path);
   if (!details.isFile()) {

--- a/src/renderer/src/components/ArtifactActions.tsx
+++ b/src/renderer/src/components/ArtifactActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Artifact } from "@shared/contracts";
+import { readableError } from "../lib/errors";
 import { Icon } from "./Icon";
 
 export interface ArtifactTarget {
@@ -35,10 +36,7 @@ export function ArtifactActions({
         setFeedback({ message: "Deleted", error: false });
       }
     } catch (error) {
-      setFeedback({
-        message: error instanceof Error ? error.message : String(error),
-        error: true,
-      });
+      setFeedback({ message: readableError(error), error: true });
     } finally {
       if (action === "delete") setConfirmingDelete(false);
       setPendingAction(null);

--- a/src/renderer/src/components/ChatMarkdown.tsx
+++ b/src/renderer/src/components/ChatMarkdown.tsx
@@ -1,17 +1,86 @@
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import type { Artifact } from "@shared/contracts";
+import { readableError } from "../lib/errors";
 
-export function ChatMarkdown({ children }: { children: string }) {
+const browsableSchemes = ["http:", "https:", "mailto:"];
+
+function isBrowsable(href: string): boolean {
+  return browsableSchemes.some((scheme) => href.toLowerCase().startsWith(scheme));
+}
+
+/**
+ * Models often advertise a file they wrote with a link they invented, such as
+ * `sandbox:/mnt/data/report.csv` or a bare workspace path. Those hrefs point
+ * nowhere in the app, so match them back to a real artifact by file name.
+ */
+function matchArtifact(href: string, artifacts: Artifact[]): Artifact | undefined {
+  if (isBrowsable(href)) return undefined;
+  const name = decodeURIComponent(href.split(/[?#]/)[0] ?? "")
+    .replaceAll("\\", "/")
+    .split("/")
+    .at(-1)
+    ?.toLowerCase();
+  if (!name) return undefined;
+  return artifacts.find((artifact) => artifact.name.toLowerCase() === name);
+}
+
+function ArtifactLink({ artifact, label }: { artifact: Artifact; label: React.ReactNode }) {
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function download() {
+    setStatus(null);
+    try {
+      const destination = await window.coworker.artifacts.download(artifact.id);
+      if (destination) setStatus("Downloaded");
+    } catch (error) {
+      setStatus(readableError(error));
+    }
+  }
+
+  return (
+    <>
+      <button
+        className="chat-markdown-artifact-link"
+        onClick={() => void download()}
+        title={`Download ${artifact.name}`}
+        type="button"
+      >
+        {label}
+      </button>
+      {status ? <small className="chat-markdown-artifact-status"> {status}</small> : null}
+    </>
+  );
+}
+
+export function ChatMarkdown({
+  children,
+  artifacts = [],
+}: {
+  children: string;
+  artifacts?: Artifact[];
+}) {
   return (
     <div className="chat-markdown">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        // Keep the raw href so invented `sandbox:` links can be matched to an
+        // artifact; only http(s)/mailto ever reach an anchor below.
+        urlTransform={(url) => url}
         components={{
-          a: ({ children: label, href }) => (
-            <a href={href} rel="noreferrer" target="_blank">
-              {label}
-            </a>
-          ),
+          a: ({ children: label, href }) => {
+            const artifact = href ? matchArtifact(href, artifacts) : undefined;
+            if (artifact) return <ArtifactLink artifact={artifact} label={label} />;
+            if (!href || !isBrowsable(href)) {
+              return <span className="chat-markdown-dead-link">{label}</span>;
+            }
+            return (
+              <a href={href} rel="noreferrer" target="_blank">
+                {label}
+              </a>
+            );
+          },
           img: ({ alt }) => <span className="chat-markdown-image-note">[Image: {alt || "image"}]</span>,
         }}
       >

--- a/src/renderer/src/components/ChatMarkdown.tsx
+++ b/src/renderer/src/components/ChatMarkdown.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Artifact } from "@shared/contracts";
-import { readableError } from "../lib/errors";
+import { ArtifactActions, artifactExtension, artifactKind } from "./ArtifactActions";
+import { Icon } from "./Icon";
+import { formatRelativeTime } from "./Primitives";
 
 const browsableSchemes = ["http:", "https:", "mailto:"];
 
@@ -26,31 +27,26 @@ function matchArtifact(href: string, artifacts: Artifact[]): Artifact | undefine
   return artifacts.find((artifact) => artifact.name.toLowerCase() === name);
 }
 
-function ArtifactLink({ artifact, label }: { artifact: Artifact; label: React.ReactNode }) {
-  const [status, setStatus] = useState<string | null>(null);
-
-  async function download() {
-    setStatus(null);
-    try {
-      const destination = await window.coworker.artifacts.download(artifact.id);
-      if (destination) setStatus("Downloaded");
-    } catch (error) {
-      setStatus(readableError(error));
-    }
-  }
-
+/**
+ * Rendered in place of the link, so a created file reads as a file — name,
+ * kind, and the same Open/Download actions as the Files panel. Built from
+ * inline elements because Markdown drops it inside a paragraph.
+ */
+function ChatArtifactCard({ artifact }: { artifact: Artifact }) {
   return (
-    <>
-      <button
-        className="chat-markdown-artifact-link"
-        onClick={() => void download()}
-        title={`Download ${artifact.name}`}
-        type="button"
-      >
-        {label}
-      </button>
-      {status ? <small className="chat-markdown-artifact-status"> {status}</small> : null}
-    </>
+    <span className="chat-artifact-card">
+      <span className="chat-artifact-icon">
+        <Icon name="file" />
+        <small>{artifactExtension(artifact)}</small>
+      </span>
+      <span className="chat-artifact-copy">
+        <strong title={artifact.name}>{artifact.name}</strong>
+        <small>
+          {artifactKind(artifact)} · {formatRelativeTime(artifact.createdAt)}
+        </small>
+        <ArtifactActions target={{ id: artifact.id, name: artifact.name }} />
+      </span>
+    </span>
   );
 }
 
@@ -71,7 +67,7 @@ export function ChatMarkdown({
         components={{
           a: ({ children: label, href }) => {
             const artifact = href ? matchArtifact(href, artifacts) : undefined;
-            if (artifact) return <ArtifactLink artifact={artifact} label={label} />;
+            if (artifact) return <ChatArtifactCard artifact={artifact} />;
             if (!href || !isBrowsable(href)) {
               return <span className="chat-markdown-dead-link">{label}</span>;
             }

--- a/src/renderer/src/lib/errors.ts
+++ b/src/renderer/src/lib/errors.ts
@@ -1,0 +1,8 @@
+/**
+ * Electron wraps main-process failures as `Error invoking remote method '…': Error: …`.
+ * Strip that prefix so the panel shows the reason instead of the plumbing.
+ */
+export function readableError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/^Error invoking remote method '[^']+':\s*(?:Error:\s*)?/, "");
+}

--- a/src/renderer/src/pages/CoworkerDetailPage.tsx
+++ b/src/renderer/src/pages/CoworkerDetailPage.tsx
@@ -1102,7 +1102,7 @@ function CoworkerSurface({
                         {content ? (
                           <span className="workroom-message-text">
                             {message.role === "assistant" ? (
-                              <ChatMarkdown>{content}</ChatMarkdown>
+                              <ChatMarkdown artifacts={artifacts}>{content}</ChatMarkdown>
                             ) : (
                               content
                             )}

--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
 import { Icon } from "../components/Icon";
 import { ModelSelector } from "../components/ModelSelector";
 import { PageHeader } from "../components/Primitives";
+import { readableError } from "../lib/errors";
 
 type SettingsTab = "general" | "models" | "skills" | "integrations" | "data";
 
@@ -29,14 +30,6 @@ function bytesToBase64(buffer: ArrayBuffer): string {
     binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
   }
   return btoa(binary);
-}
-
-function readableError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(
-    /^Error invoking remote method '[^']+':\s*(?:Error:\s*)?/,
-    "",
-  );
 }
 
 export function SettingsPage({

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3629,6 +3629,25 @@ select:focus {
   font-style: italic;
 }
 
+.chat-markdown-artifact-link {
+  background: none;
+  border: 0;
+  color: var(--blue);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.chat-markdown-artifact-status {
+  color: var(--ink-soft);
+}
+
+.chat-markdown-dead-link {
+  color: var(--ink-soft);
+}
+
 .workroom-message-meta {
   color: #87948e;
   font-family: var(--mono);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3629,19 +3629,82 @@ select:focus {
   font-style: italic;
 }
 
-.chat-markdown-artifact-link {
-  background: none;
-  border: 0;
-  color: var(--blue);
-  cursor: pointer;
-  font: inherit;
-  padding: 0;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+/* A file the coworker created, shown inline in the message. Mirrors
+   .conversation-file-card, built from inline elements so Markdown can nest it
+   inside a paragraph. */
+.chat-artifact-card {
+  display: inline-grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  align-items: start;
+  gap: 9px;
+  width: 100%;
+  max-width: 330px;
+  margin: 6px 0 2px;
+  padding: 9px;
+  background: #fff;
+  border: 1px solid #dde5e0;
+  border-radius: 10px;
+  box-shadow: 0 4px 14px rgba(31, 44, 38, 0.03);
+  text-align: left;
+  vertical-align: top;
 }
 
-.chat-markdown-artifact-status {
+.chat-artifact-icon {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 42px;
+  color: var(--blue);
+  background: var(--blue-soft);
+  border: 1px solid #cfdbf7;
+  border-radius: 7px;
+}
+
+.chat-artifact-icon svg {
+  width: 16px;
+  height: 16px;
+  transform: translateY(-4px);
+}
+
+.chat-artifact-icon small {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  left: 3px;
+  overflow: hidden;
+  color: #4962a9;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 760;
+  text-align: center;
+  text-overflow: ellipsis;
+}
+
+.chat-artifact-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.chat-artifact-copy strong {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 660;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-artifact-copy > small {
+  margin-top: 2px;
   color: var(--ink-soft);
+  font-size: 10px;
+}
+
+.chat-artifact-copy > .artifact-actions {
+  width: 100%;
+  margin-top: 7px;
+  flex-wrap: wrap;
 }
 
 .chat-markdown-dead-link {

--- a/tests/artifact-files.test.ts
+++ b/tests/artifact-files.test.ts
@@ -57,6 +57,44 @@ describe("artifact file access", () => {
     }
   });
 
+  it("resolves files recorded under a differently cased workspace root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "coworker-artifacts-"));
+    temporaryPaths.push(root);
+    const workspace = join(root, "Workspace");
+    const filePath = join(workspace, "seedance_profiles.csv");
+    await mkdir(workspace, { recursive: true });
+    await writeFile(filePath, "a,b\n1,2\n");
+
+    const database = new CoworkerDatabase(join(root, "coworker.db"));
+    try {
+      const coworker = database.createCoworker(
+        {
+          name: "Song",
+          role: "Social Media Expert",
+          systemPrompt: "Research profiles.",
+          modelProvider: "demo",
+          modelName: "faux-1",
+          enabledTools: ["documents.export"],
+        },
+        workspace,
+      );
+      const artifact = database.createArtifact({
+        taskId: null,
+        coworkerId: coworker.id,
+        name: "seedance_profiles.csv",
+        mimeType: "text/csv",
+        // The same directory, spelled the way the app resolved it when writing.
+        filePath: join(root, "workspace", "seedance_profiles.csv"),
+      });
+
+      await expect(resolveArtifactFile(database, artifact.id)).resolves.toMatchObject({
+        artifact: { id: artifact.id },
+      });
+    } finally {
+      database.close();
+    }
+  });
+
   it("rejects artifact records that point outside the coworker workspace", async () => {
     const root = await mkdtemp(join(tmpdir(), "coworker-artifacts-"));
     temporaryPaths.push(root);

--- a/tests/chat-markdown.test.tsx
+++ b/tests/chat-markdown.test.tsx
@@ -37,15 +37,18 @@ describe("coworker response Markdown", () => {
     expect(html).not.toContain("<script>");
   });
 
-  it("turns an invented file link into a download for the matching artifact", () => {
+  it("renders an invented file link as a file card for the matching artifact", () => {
     const html = renderToStaticMarkup(
       <ChatMarkdown artifacts={[csv]}>
         {"[Download the CSV](sandbox:/mnt/data/seedance_2_5_profiles.csv)"}
       </ChatMarkdown>,
     );
 
-    expect(html).toContain('class="chat-markdown-artifact-link"');
-    expect(html).toContain("Download the CSV");
+    expect(html).toContain('class="chat-artifact-card"');
+    expect(html).toContain("seedance_2_5_profiles.csv");
+    expect(html).toContain("CSV spreadsheet");
+    expect(html).toContain('aria-label="Open seedance_2_5_profiles.csv"');
+    expect(html).toContain('aria-label="Download seedance_2_5_profiles.csv"');
     expect(html).not.toContain("sandbox:/mnt/data");
   });
 
@@ -74,5 +77,17 @@ describe("coworker response Markdown", () => {
 
     expect(html).not.toContain("<a ");
     expect(html).not.toContain("javascript:");
+  });
+
+  it("keeps the file card nestable inside a Markdown paragraph", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown artifacts={[csv]}>
+        {"Created the CSV spreadsheet:\n\n[Download the CSV](sandbox:/mnt/data/seedance_2_5_profiles.csv)"}
+      </ChatMarkdown>,
+    );
+
+    const card = html.slice(html.indexOf('class="chat-artifact-card"'));
+    expect(card).not.toMatch(/<(div|article|section|p|ul|ol)\b/);
+    expect(html).toContain("Created the CSV spreadsheet:");
   });
 });

--- a/tests/chat-markdown.test.tsx
+++ b/tests/chat-markdown.test.tsx
@@ -1,6 +1,17 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { Artifact } from "@shared/contracts";
 import { ChatMarkdown } from "@renderer/components/ChatMarkdown";
+
+const csv: Artifact = {
+  id: "artifact-1",
+  taskId: null,
+  coworkerId: "coworker-1",
+  name: "seedance_2_5_profiles.csv",
+  mimeType: "text/csv",
+  filePath: "/workspace/seedance_2_5_profiles.csv",
+  createdAt: new Date().toISOString(),
+};
 
 describe("coworker response Markdown", () => {
   it("renders common Markdown and does not execute raw HTML", () => {
@@ -24,5 +35,44 @@ describe("coworker response Markdown", () => {
     expect(html).toContain("<strong>Ready</strong>");
     expect(html).toContain("<code>inline</code>");
     expect(html).not.toContain("<script>");
+  });
+
+  it("turns an invented file link into a download for the matching artifact", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown artifacts={[csv]}>
+        {"[Download the CSV](sandbox:/mnt/data/seedance_2_5_profiles.csv)"}
+      </ChatMarkdown>,
+    );
+
+    expect(html).toContain('class="chat-markdown-artifact-link"');
+    expect(html).toContain("Download the CSV");
+    expect(html).not.toContain("sandbox:/mnt/data");
+  });
+
+  it("does not render an unusable link as a clickable anchor", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown artifacts={[]}>{"[Download the CSV](sandbox:/mnt/data/other.csv)"}</ChatMarkdown>,
+    );
+
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("Download the CSV");
+  });
+
+  it("keeps ordinary web links clickable", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown artifacts={[csv]}>{"[Docs](https://example.com/docs)"}</ChatMarkdown>,
+    );
+
+    expect(html).toContain('href="https://example.com/docs"');
+  });
+
+  it("never renders a javascript: link as an anchor", () => {
+    const html = renderToStaticMarkup(
+      // eslint-disable-next-line no-script-url
+      <ChatMarkdown artifacts={[]}>{"[Click me](javascript:alert(1))"}</ChatMarkdown>,
+    );
+
+    expect(html).not.toContain("<a ");
+    expect(html).not.toContain("javascript:");
   });
 });


### PR DESCRIPTION
Opening or downloading a file a coworker created failed with `Path traversal outside the coworker workspace is blocked`, and the link to that file in the chat was dead. Both are fixed here.

## The bug

`resolveArtifactFile` derived the workspace-relative path with `path.relative`, which is case-sensitive on POSIX. A workspace root recorded as `.../Coworker` therefore did not match files recorded under `.../coworker` — the same directory on macOS — and the derived path came out as `../../../coworker/...`, which `resolveWorkspacePath` correctly rejected.

Both spellings occur because `package.json` sets `"name": "coworker"` and `"productName": "Coworker"`: `app.getPath("userData")` resolves through `productName`, while the directory on disk is lowercase. Every Open and Download for an affected coworker failed.

The fix matches the root case-insensitively on macOS and Windows, keeping the original casing of the tail segments. Paths genuinely outside the workspace are still rejected — the existing security test covers that and still passes.

`productName` is deliberately left alone; changing it would move the userData directory and orphan existing databases.

## Dead links in the chat

Models advertise a file they wrote with an invented href such as `sandbox:/mnt/data/report.csv`. react-markdown sanitized the unknown scheme to an empty href, so it rendered as a blue underlined link that did nothing when clicked.

Those links are now matched back to a real artifact by file name and rendered as a file card — type badge, name, kind, and the same Open/Download actions the Files panel uses. Unmatched non-web links render as plain text rather than a fake link. Only `http(s)` and `mailto` ever reach an anchor, so disabling the URL sanitizer does not let a `javascript:` URL through; there is a test for that.

The card is built from inline elements because Markdown nests it inside a `<p>`, where a `<div>` would be hoisted out by the parser. A test pins this so a block-level element cannot creep back in.

## Also

`readableError` is extracted to `src/renderer/src/lib/errors.ts` and used by the Files panel, which previously showed the truncated `Error invoking remote method '...'` wrapper instead of the actual reason.

## Verification

Typecheck clean; 119/119 tests pass, including 5 new ones.

Beyond the unit tests, this was driven in the running Electron app against a copy of a real database that reproduced the casing mismatch, stubbing only `shell.openPath` and `dialog.showSaveDialog` so the IPC handlers and `resolveArtifactFile` ran for real:

| | before | after |
|---|---|---|
| Open | `Path traversal outside the coworker workspace is blocked` | `Opened` |
| Download | same error | `Downloaded`, 2500 bytes written |
| Chat link | dead `sandbox:` anchor | file card, both buttons working |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr5janfaXRH2LZ7BjgH9hK
