### PR TITLE
build: publish multi-platform installers to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+# Tagging v* builds installers for macOS, Windows and Linux and attaches them
+# to a GitHub release. workflow_dispatch rebuilds an existing tag on demand.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and publish (e.g. v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: mac
+          - os: windows-latest
+            platform: win
+          - os: ubuntu-latest
+            platform: linux
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build installers
+        env:
+          # No Developer ID certificate yet, so keep electron-builder from
+          # picking up an unrelated keychain identity and failing the build.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: pnpm dist:${{ matrix.platform }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coworker-${{ matrix.platform }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/*.exe
+            release/*.AppImage
+            release/*.deb
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: List artifacts
+        run: ls -lh dist
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          cat > notes.md <<'NOTES'
+          ## Downloads
+
+          | Platform | File |
+          | --- | --- |
+          | macOS (Apple silicon) | `Coworker-*-mac-arm64.dmg` |
+          | macOS (Intel) | `Coworker-*-mac-x64.dmg` |
+          | Windows | `Coworker-*-win-x64-setup.exe` (or `arm64`) |
+          | Linux | `Coworker-*-linux-x64.AppImage` / `.deb` |
+
+          These builds are **not code-signed**.
+
+          - macOS: the first launch is blocked by Gatekeeper. Right-click the app and
+            choose *Open*, or run `xattr -dr com.apple.quarantine "/Applications/Coworker.app"`.
+          - Windows: SmartScreen shows "Windows protected your PC" — choose
+            *More info* → *Run anyway*.
+          - Linux: `chmod +x Coworker-*.AppImage` before running it.
+          NOTES
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --title "Coworker $TAG" \
+              --notes-file notes.md \
+              --generate-notes
+          fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A local-first Electron app for running independent AI coworkers. Each coworker has its own durable task queue, an isolated worker runtime, a confined workspace, and policy-controlled tools — so it can do real work (documents, invoices, email drafts, scheduled reminders) without arbitrary code execution.
 
+## Download
+
+Prebuilt installers for macOS, Windows and Linux are attached to every
+[GitHub release](https://github.com/donvito/coworker/releases/latest).
+
+| Platform | File |
+| --- | --- |
+| macOS (Apple silicon) | `Coworker-<version>-mac-arm64.dmg` |
+| macOS (Intel) | `Coworker-<version>-mac-x64.dmg` |
+| Windows | `Coworker-<version>-win-x64-setup.exe` (also `arm64`) |
+| Linux | `Coworker-<version>-linux-x64.AppImage` or `.deb` |
+
+The builds are not code-signed yet, so the OS warns on first launch:
+
+- **macOS** — right-click the app and choose *Open*, or run
+  `xattr -dr com.apple.quarantine "/Applications/Coworker.app"`.
+- **Windows** — SmartScreen: *More info* → *Run anyway*.
+- **Linux** — `chmod +x Coworker-*.AppImage` before running it.
+
 ## Screenshots
 
 **Workroom home** — every coworker's runtime status, the decision queue, and a live desk log.
@@ -43,7 +62,8 @@ To connect a real model, open **Settings → Providers**, add credentials, and v
 | `pnpm test` | Build, then run the integration suite |
 | `pnpm eval:contract` | Run the deterministic agent evals |
 | `pnpm package` | Build an unpacked app into `release/` |
-| `pnpm dist` | Build installers (dmg/zip, nsis, AppImage) |
+| `pnpm dist` | Build installers for the current platform into `release/` |
+| `pnpm dist:mac` / `dist:win` / `dist:linux` | Build installers for one platform |
 
 `pnpm test` builds the production worker first, then verifies queue isolation, concurrent workers, approval pause/resume, idempotency, scheduler recovery, and workspace confinement.
 
@@ -118,6 +138,26 @@ State lives under Electron's user-data directory. Model and email API keys are e
 The renderer runs with context isolation, sandboxing, no Node integration, a restrictive CSP, and a narrow preload API. Workers cannot touch SQLite or credentials directly. File tools resolve paths against the coworker's workspace and reject traversal or escaping symlinks. Attached images are validated and capped at four images / 20 MB per message. Remote skill downloads reject credential-bearing, local, and private-network URLs, and bundled skills cannot be overwritten. There is deliberately no shell, Python, or code-execution tool.
 
 Provider, catalog, startup, inference, and runtime-exit failures are written as redacted JSON Lines to `logs/provider-errors.jsonl` in the same directory (provider/model and task/run IDs, no prompts or credentials; rotates at 5 MB). Recent entries are viewable in **Settings → Data**, where a redacted support report can be copied or exported.
+
+## Releasing
+
+Installers are built by [`.github/workflows/release.yml`](.github/workflows/release.yml)
+on a matrix of macOS, Windows and Ubuntu runners, then attached to a GitHub release.
+
+```sh
+# bump "version" in package.json first
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Pushing a `v*` tag builds all three platforms and publishes the release. Re-running the
+workflow manually (**Actions → Release → Run workflow**) with an existing tag rebuilds it
+and re-uploads the assets to the same release.
+
+Nothing in the dependency tree is native — the database is `node:sqlite` — so each runner
+packages its own platform without a rebuild toolchain. Signing is not configured: add
+`CSC_LINK`/`CSC_KEY_PASSWORD` (macOS) and `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` (Windows)
+as repository secrets, and drop `identity: null` from `build.mac`, once certificates exist.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Coworker",
   "license": "UNLICENSED",
   "private": true,
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@9.15.0",
   "engines": {
     "node": ">=22.12.0"
   },
@@ -28,35 +28,92 @@
     "eval:report:contract": "node -e \"require('node:fs').mkdirSync('eval-results',{recursive:true})\" && pnpm build && vitest run --config vitest.evals.config.ts evals/tool-safety.eval.ts evals/multimodal.eval.ts --reporter=vitest-evals/reporter --reporter=json --outputFile.json=eval-results/latest.json",
     "eval:ui": "vitest-evals serve eval-results",
     "package": "pnpm build && electron-builder --dir",
-    "dist": "pnpm build && electron-builder"
+    "dist": "pnpm build && electron-builder --publish never",
+    "dist:mac": "pnpm build && electron-builder --mac --publish never",
+    "dist:win": "pnpm build && electron-builder --win --publish never",
+    "dist:linux": "pnpm build && electron-builder --linux --publish never"
   },
   "build": {
     "appId": "com.localcoworker.desktop",
     "productName": "Coworker",
     "directories": {
-      "output": "release"
+      "output": "release",
+      "buildResources": "build"
     },
     "files": [
       "out/**/*",
       "build/icon.png",
       "package.json"
     ],
+    "npmRebuild": false,
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "donvito",
+        "repo": "coworker"
+      }
+    ],
     "mac": {
       "icon": "build/icon.png",
+      "category": "public.app-category.productivity",
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
       ],
-      "category": "public.app-category.productivity"
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
+      "darkModeSupport": true,
+      "identity": null,
+      "notarize": false
     },
     "win": {
       "icon": "build/icon.png",
-      "target": "nsis"
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "${productName}-${version}-win-${arch}-setup.${ext}"
     },
     "linux": {
       "icon": "build/icon.png",
-      "target": "AppImage",
-      "category": "Utility"
+      "category": "Utility",
+      "maintainer": "donvito <melvindave@gmail.com>",
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "artifactName": "${productName}-${version}-linux-${arch}.${ext}"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Adds a tag-driven release pipeline so Coworker is downloadable from GitHub releases.

## What this does

Pushing a `v*` tag builds the app on macOS, Windows and Ubuntu runners and attaches the installers to a GitHub release.

| Platform | Artifacts |
| --- | --- |
| macOS | `dmg` + `zip`, `arm64` and `x64` |
| Windows | `nsis` installer, `x64` and `arm64` |
| Linux | `AppImage` + `deb`, `x64` |

## Changes

- `.github/workflows/release.yml` — matrix build, artifact upload, then one `publish` job that creates the release with `gh` (re-running with an existing tag re-uploads assets instead of failing).
- `package.json` — per-platform electron-builder targets, predictable artifact names (`Coworker-<version>-<os>-<arch>.<ext>`), `identity: null` (no Developer ID cert yet), `npmRebuild: false` (nothing in the tree is native — the database is `node:sqlite`).
- `packageManager` pinned back to `pnpm@9.15.0`. pnpm 11 no longer reads `pnpm.patchedDependencies` from `package.json`, which is exactly what broke `--frozen-lockfile` in CI and forced the evals workflow onto manual triggers. That blocker is now gone if you want to re-enable eval runs.
- README: download table, unsigned-build warnings per OS, and the tag flow.

## Verification

Ran the full macOS build locally — exit 0, four artifacts, correct bundle metadata:

```
Coworker-0.1.0-mac-arm64.dmg   196M
Coworker-0.1.0-mac-arm64.zip   194M
Coworker-0.1.0-mac-x64.dmg     198M
Coworker-0.1.0-mac-x64.zip     196M
```

`CFBundleName=Coworker`, `CFBundleIdentifier=com.localcoworker.desktop`, icon converted to `.icns`. `pnpm install --frozen-lockfile` verified against pnpm 9.15.0. Windows and Linux are covered by the matrix but were not built locally.

## Not included

Code signing and notarization. The builds are unsigned, so macOS Gatekeeper and Windows SmartScreen warn on first launch — the README and release notes document the workaround for each OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Bv3aaPmsArYfGLPULearB