### PR TITLE
build: stop emitting the combined Windows installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
       "oneClick": false,
       "perMachine": false,
       "allowToChangeInstallationDirectory": true,
+      "buildUniversalInstaller": false,
       "artifactName": "${productName}-${version}-win-${arch}-setup.${ext}"
     },
     "linux": {


### PR DESCRIPTION
The v0.1.0 release shipped three Windows installers:

```
Coworker-0.1.0-win-x64-setup.exe     154MB
Coworker-0.1.0-win-arm64-setup.exe   146MB
Coworker-0.1.0-win-setup.exe         300MB   <- combined x64 + arm64
```

`NsisOptions.buildUniversalInstaller` defaults to `true`, so building for two architectures also produces a combined installer. `${arch}` resolves to nothing for it, hence the unlabeled name.

Setting it to `false` leaves one installer per architecture, matching the per-arch macOS dmgs and the download table in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Bv3aaPmsArYfGLPULearB
