### PR TITLE
docs: slim the main README and split the rest into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,31 @@
 # Coworker
 
-A local-first Electron app for running independent AI coworkers. Each coworker has its own durable task queue, an isolated worker runtime, a confined workspace, and policy-controlled tools — so it can do real work (documents, invoices, email drafts, scheduled reminders) without arbitrary code execution.
-
-## Download
-
-Prebuilt installers for macOS, Windows and Linux are attached to every
-[GitHub release](https://github.com/donvito/coworker/releases/latest).
-
-| Platform | File |
-| --- | --- |
-| macOS (Apple silicon) | `Coworker-<version>-mac-arm64.dmg` |
-| macOS (Intel) | `Coworker-<version>-mac-x64.dmg` |
-| Windows | `Coworker-<version>-win-x64-setup.exe` (also `arm64`) |
-| Linux | `Coworker-<version>-linux-x64.AppImage` or `.deb` |
-
-The builds are not code-signed yet, so the OS warns on first launch:
-
-- **macOS** — right-click the app and choose *Open*, or run
-  `xattr -dr com.apple.quarantine "/Applications/Coworker.app"`.
-- **Windows** — SmartScreen: *More info* → *Run anyway*.
-- **Linux** — `chmod +x Coworker-*.AppImage` before running it.
-
-## Screenshots
-
-**Team room** — the floor at a glance, a composer that puts any coworker to work, and a live activity log.
+AI agents for your work, running on your own computer.
 
 ![Team room](docs/images/home.png)
 
-**Coworkers** — each one has an independent runtime, workspace, and single focused task queue.
+Coworker is a local-first desktop app for independent AI coworkers. There is **no subscription**. The app runs on **your computer**, talks to **local models** or keys you bring, learns new **skills**, keeps a **scheduler**, pauses on **approvals**, and can meet you on **Telegram**.
 
-![Coworkers](docs/images/coworkers.png)
+[More screenshots](docs/screenshots.md) · [What it can do](docs/features.md)
 
-**Chat** — streaming Markdown replies, per-coworker model switching, and the files a coworker writes into its own workspace.
+## Why Coworker
 
-![Coworker chat](docs/images/coworker-chat.png)
+- **No subscription** — free to download and use. Pay a model provider only if you choose one.
+- **Runs on your computer** — macOS, Windows, and Linux. Conversations, files, and app data stay on the machine.
+- **Local models** — point it at [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai) and inference never leaves your machine.
+- **Bring your own keys** — Anthropic, OpenAI, Google, OpenRouter, or any OpenAI-compatible endpoint. Credentials stay in OS-backed storage.
+- **Skills** — coworkers learn new capabilities from Agent Skills. Upload a `SKILL.md`, add an HTTPS URL, or paste a skill link into chat.
+- **Scheduler** — persistent cron and one-time jobs, in plain language, with crash recovery.
+- **Approvals** — consequential actions pause until you approve or reject them, in the app or from Telegram.
+- **Telegram** — pair a private chat and message a coworker from your phone. Replies, files, and approval buttons stay in sync with the desktop.
 
-**Approvals** — consequential actions pause here, and decisions are written to SQLite before work resumes.
+## Download
 
-![Approvals](docs/images/approvals.png)
+Prebuilt installers for **macOS**, **Windows**, and **Linux** are on every [GitHub release](https://github.com/donvito/coworker/releases/latest).
 
-## Quick start
+The builds are not code-signed yet, so the OS warns on first launch. See [install notes](docs/releasing.md#after-you-download).
+
+## Development
 
 Requires **Node.js 22.12+** and **pnpm**.
 
@@ -48,131 +34,18 @@ pnpm install
 pnpm dev
 ```
 
-Unpackaged development builds use a separate **Coworker Development** data profile. Set
-`COWORKER_DATA_PATH` to an absolute directory to use another isolated profile; packaged builds
-continue using the normal production data directory.
+Unpackaged development builds use a separate **Coworker Development** data profile. Set `COWORKER_DATA_PATH` to an absolute directory to use another isolated profile; packaged builds continue using the normal production data directory.
 
 The app ships with two demo coworkers — **Ava** (accounting) and **Sarah** (sales) — that run on a built-in faux provider, so you can try the full flow without an API key.
 
-To connect a real model, open **Settings → Providers**, add credentials, and verify the provider. Supported: Anthropic, OpenAI, Google, OpenRouter, Ollama, LM Studio, and any custom OpenAI-compatible endpoint. Ollama (`http://127.0.0.1:11434/v1`) and LM Studio (`http://127.0.0.1:1234/v1`) work without an API key.
+To connect a real model, open **Settings → Providers**, add credentials, and verify the provider. Ollama (`http://127.0.0.1:11434/v1`) and LM Studio (`http://127.0.0.1:1234/v1`) work without an API key.
 
-### Scripts
+Scripts, tests, evals, and packaging: [Development](docs/development.md)
 
-| Command | What it does |
-| --- | --- |
-| `pnpm dev` | Run the app in development |
-| `pnpm typecheck` | TypeScript check, no emit |
-| `pnpm build` | Typecheck + production build |
-| `pnpm db:generate` | Generate a versioned SQLite migration from the Drizzle schema |
-| `pnpm db:check` | Validate the Drizzle migration history |
-| `pnpm test` | Build, then run the integration suite |
-| `pnpm eval:contract` | Run the deterministic agent evals |
-| `pnpm package` | Build an unpacked app into `release/` |
-| `pnpm dist` | Build installers for the current platform into `release/` |
-| `pnpm dist:mac` / `dist:win` / `dist:linux` | Build installers for one platform |
+## Docs
 
-`pnpm test` builds the production worker first, then verifies queue isolation, concurrent workers, approval pause/resume, idempotency, scheduler recovery, and workspace confinement.
-
-## Features
-
-**Coworkers and chat**
-- Multiple coworkers, each with its own role, system prompt, tool set, and workspace
-- Direct conversations with one coworker and shared group channels with two or more coworkers
-- Channel messages reach every member by default; typed `@mentions` narrow a request to specific coworkers
-- Channel requests involving two or more coworkers become turn-based discussions: each coworker sees the latest shared transcript, decides whether it has something to add, and passes quietly when it doesn't
-- Discussions conclude on their own when every coworker passes, with a safety check-in on unusually long discussions; reply mid-discussion to interject and steer, or stop it at any time
-- Multiple named conversations and channels persisted across restarts
-- Search conversation titles and message contents, with messages grouped and timestamped by day
-- Right-click any coworker in the chat sidebar to open their settings
-- Streaming, Markdown-rendered replies with typed tool call rendering
-- Image attachments via picker or drag-and-drop, sent to vision-capable models
-- Searchable live model catalogs with OpenRouter pricing and quick per-coworker model switching
-
-**Work execution**
-- One task at a time per coworker, on an isolated Node worker thread
-- Durable SQLite task queue with checkpoints, history, artifacts, and crash recovery
-- Approval inbox with editable decisions and idempotent resume
-- Persistent cron and one-time schedules; chat reminders route to the approval-gated scheduler
-
-**Tools**
-- Confined file read/list/write inside the coworker workspace
-- Invoice creation
-- Document export to PDF, Word DOCX, Excel XLSX, and CSV from semantic Markdown
-- Email drafts (`.eml` outbox by default) and approval-gated sending via Resend
-- Web search with Tavily, Exa, Firecrawl, and SerpAPI credential fallback
-
-**Skills**
-- Agent Skills-compatible global skill library with per-coworker enablement
-- Bundled `web-search`, `document-authoring`, and `team-channel-collaboration` skills
-- Install by uploading a `SKILL.md`, from an HTTPS URL in Settings, or by pasting a skill URL into chat
-- Metadata is exposed to the model first; full instructions load on demand through a controlled skill reader
-
-**Platform**
-- Tray/background operation and launch-at-login controls
-- electron-builder packaging for macOS, Windows, and Linux
-- OS-backed encrypted model and integration credentials
-- Redacted application diagnostics with downloadable ZIP support bundles
-- Complete ZIP backups of conversations, database state, coworker workspaces, and outbox files
-
-## Agent evals
-
-The Vitest Evals suite exercises production worker threads and controlled tools, not mocked agent facades. It is split by what each suite can honestly measure.
-
-**Contract evals** (`evals/tool-safety`, `evals/multimodal`) assert deterministic policy: path confinement, malformed tool input, approval gating, idempotent side effects, and image validation. No model is involved, so these gate every push.
-
-```sh
-pnpm eval:contract      # keyless, deterministic — the CI gate
-pnpm eval:report:contract   # also writes eval-results/latest.json
-pnpm eval:ui            # browse the report
-```
-
-**Behavior evals** (`evals/coworker-behavior`) assert model judgment: which controlled tool the coworker reaches for, and in what order. Grading that against a scripted stand-in would only measure the script, so each scenario runs against a real provider once and replays the recorded turns afterwards.
-
-Recordings live in `evals/recordings/` and are currently **local and gitignored**, so these evals skip in CI rather than gate it. Committing that directory is what turns them into a CI gate; until then they are a local tool.
-
-```sh
-pnpm eval:behavior      # replay the committed recordings
-
-EVAL_PROVIDER=openai \
-EVAL_MODEL=gpt-4.1-mini \
-EVAL_API_KEY=... \
-pnpm eval:record        # re-record against a live provider
-```
-
-A scenario with no recording and no live provider is skipped, never graded against a stand-in. Re-record whenever a prompt, tool surface, or system prompt changes — a stale recording is a stale claim about the model.
-
-A scenario marked `liveOnly` never replays. Its recorded turns reference an identifier the app generated during recording (an invoice number derives from a per-run task id), which a replay regenerates differently, so replaying it would assert nothing.
-
-`EVAL_PROVIDER` accepts `anthropic`, `openai`, `google`, or `openrouter`. A provider-specific key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`) can be used instead of `EVAL_API_KEY`. Live runs may incur provider charges; the contract suite never makes remote calls.
-
-## Data and security
-
-State lives under Electron's user-data directory. Model and email API keys are encrypted with Electron `safeStorage` — plaintext keys are never written to SQLite or returned to the renderer.
-
-The renderer runs with context isolation, sandboxing, no Node integration, a restrictive CSP, and a narrow preload API. Workers cannot touch SQLite or credentials directly. File tools resolve paths against the coworker's workspace and reject traversal or escaping symlinks. Attached images are validated and capped at four images / 20 MB per message. Remote skill downloads reject credential-bearing, local, and private-network URLs, and bundled skills cannot be overwritten. There is deliberately no shell, Python, or code-execution tool.
-
-Provider, catalog, startup, inference, and runtime-exit failures are written as redacted JSON Lines to `logs/provider-errors.jsonl` in the same directory (provider/model and task/run IDs, no prompts or credentials; rotates at 5 MB). Recent entries are viewable in **Settings → Data**, where a redacted support report can be copied or exported.
-
-## Releasing
-
-Installers are built by [`.github/workflows/release.yml`](.github/workflows/release.yml)
-on a matrix of macOS, Windows and Ubuntu runners, then attached to a GitHub release.
-
-```sh
-# bump "version" in package.json first
-git tag v0.1.0
-git push origin v0.1.0
-```
-
-Pushing a `v*` tag builds all three platforms and publishes the release. Re-running the
-workflow manually (**Actions → Release → Run workflow**) with an existing tag rebuilds it
-and re-uploads the assets to the same release.
-
-Nothing in the dependency tree is native — the database is `node:sqlite` — so each runner
-packages its own platform without a rebuild toolchain. Signing is not configured: add
-`CSC_LINK`/`CSC_KEY_PASSWORD` (macOS) and `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` (Windows)
-as repository secrets, and drop `identity: null` from `build.mac`, once certificates exist.
-
-## Contributing
-
-New coworker capabilities are delivered as Agent Skills rather than hardcoded application logic. See [AGENTS.md](AGENTS.md) for the capability architecture and verification expectations.
+- [Screenshots](docs/screenshots.md)
+- [Features](docs/features.md)
+- [Development](docs/development.md)
+- [Data and security](docs/security.md)
+- [Releasing](docs/releasing.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,57 @@
+# Development
+
+Requires **Node.js 22.12+** and **pnpm**. See the [main README](../README.md#development) for the quick start.
+
+## Scripts
+
+| Command | What it does |
+| --- | --- |
+| `pnpm dev` | Run the app in development |
+| `pnpm typecheck` | TypeScript check, no emit |
+| `pnpm build` | Typecheck + production build |
+| `pnpm db:generate` | Generate a versioned SQLite migration from the Drizzle schema |
+| `pnpm db:check` | Validate the Drizzle migration history |
+| `pnpm test` | Build, then run the integration suite |
+| `pnpm eval:contract` | Run the deterministic agent evals |
+| `pnpm package` | Build an unpacked app into `release/` |
+| `pnpm dist` | Build installers for the current platform into `release/` |
+| `pnpm dist:mac` / `dist:win` / `dist:linux` | Build installers for one platform |
+
+`pnpm test` builds the production worker first, then verifies queue isolation, concurrent workers, approval pause/resume, idempotency, scheduler recovery, and workspace confinement.
+
+## Agent evals
+
+The Vitest Evals suite exercises production worker threads and controlled tools, not mocked agent facades. It is split by what each suite can honestly measure.
+
+**Contract evals** (`evals/tool-safety`, `evals/multimodal`) assert deterministic policy: path confinement, malformed tool input, approval gating, idempotent side effects, and image validation. No model is involved, so these gate every push.
+
+```sh
+pnpm eval:contract      # keyless, deterministic — the CI gate
+pnpm eval:report:contract   # also writes eval-results/latest.json
+pnpm eval:ui            # browse the report
+```
+
+**Behavior evals** (`evals/coworker-behavior`) assert model judgment: which controlled tool the coworker reaches for, and in what order. Grading that against a scripted stand-in would only measure the script, so each scenario runs against a real provider once and replays the recorded turns afterwards.
+
+Recordings live in `evals/recordings/` and are currently **local and gitignored**, so these evals skip in CI rather than gate it. Committing that directory is what turns them into a CI gate; until then they are a local tool.
+
+```sh
+pnpm eval:behavior      # replay the committed recordings
+
+EVAL_PROVIDER=openai \
+EVAL_MODEL=gpt-4.1-mini \
+EVAL_API_KEY=... \
+pnpm eval:record        # re-record against a live provider
+```
+
+A scenario with no recording and no live provider is skipped, never graded against a stand-in. Re-record whenever a prompt, tool surface, or system prompt changes — a stale recording is a stale claim about the model.
+
+A scenario marked `liveOnly` never replays. Its recorded turns reference an identifier the app generated during recording (an invoice number derives from a per-run task id), which a replay regenerates differently, so replaying it would assert nothing.
+
+`EVAL_PROVIDER` accepts `anthropic`, `openai`, `google`, or `openrouter`. A provider-specific key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`) can be used instead of `EVAL_API_KEY`. Live runs may incur provider charges; the contract suite never makes remote calls.
+
+## Contributing
+
+New coworker capabilities are delivered as Agent Skills rather than hardcoded application logic. See [AGENTS.md](../AGENTS.md) for the capability architecture and verification expectations.
+
+Installer and release workflow: [Releasing](releasing.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,56 @@
+# Features
+
+Coworker is a local-first Electron app for independent AI coworkers. Each coworker has its own durable task queue, an isolated worker runtime, a confined workspace, and policy-controlled tools — so it can do real work (documents, invoices, email drafts, scheduled reminders) without arbitrary code execution.
+
+## Coworkers and chat
+
+- Multiple coworkers, each with its own role, system prompt, tool set, and workspace
+- Direct conversations with one coworker and shared group channels with two or more coworkers
+- Channel messages reach every member by default; typed `@mentions` narrow a request to specific coworkers
+- Channel requests involving two or more coworkers become turn-based discussions: each coworker sees the latest shared transcript, decides whether it has something to add, and passes quietly when it doesn't
+- Discussions conclude on their own when every coworker passes, with a safety check-in on unusually long discussions; reply mid-discussion to interject and steer, or stop it at any time
+- Multiple named conversations and channels persisted across restarts
+- Search conversation titles and message contents, with messages grouped and timestamped by day
+- Right-click any coworker in the chat sidebar to open their settings
+- Streaming, Markdown-rendered replies with typed tool call rendering
+- Image attachments via picker or drag-and-drop, sent to vision-capable models
+- Searchable live model catalogs with OpenRouter pricing and quick per-coworker model switching
+
+## Work execution
+
+- One task at a time per coworker, on an isolated Node worker thread
+- Durable SQLite task queue with checkpoints, history, artifacts, and crash recovery
+- Approval inbox with editable decisions and idempotent resume
+- Persistent cron and one-time schedules; chat reminders route to the approval-gated scheduler
+
+## Tools
+
+- Confined file read/list/write inside the coworker workspace
+- Invoice creation
+- Document export to PDF, Word DOCX, Excel XLSX, and CSV from semantic Markdown
+- Email drafts (`.eml` outbox by default) and approval-gated sending via Resend
+- Web search with Tavily, Exa, Firecrawl, and SerpAPI credential fallback
+
+## Skills
+
+- Agent Skills-compatible global skill library with per-coworker enablement
+- Bundled `web-search`, `document-authoring`, and `team-channel-collaboration` skills
+- Install by uploading a `SKILL.md`, from an HTTPS URL in Settings, or by pasting a skill URL into chat
+- Metadata is exposed to the model first; full instructions load on demand through a controlled skill reader
+
+## Telegram
+
+Pair a private Telegram chat and message a coworker from your phone.
+
+- Replies stream back to Telegram and mirror to the desktop conversation
+- Documents and photos move both ways
+- Approvals arrive as buttons you can tap
+- `/stop` cancels in-flight work and keeps the partial reply in both places
+
+## Platform
+
+- Tray/background operation and launch-at-login controls
+- electron-builder packaging for macOS, Windows, and Linux
+- OS-backed encrypted model and integration credentials
+- Redacted application diagnostics with downloadable ZIP support bundles
+- Complete ZIP backups of conversations, database state, coworker workspaces, and outbox files

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,39 @@
+# Releasing
+
+Installers for macOS, Windows, and Linux are attached to every [GitHub release](https://github.com/donvito/coworker/releases/latest).
+
+| Platform | File |
+| --- | --- |
+| macOS (Apple silicon) | `Coworker-<version>-mac-arm64.dmg` |
+| macOS (Intel) | `Coworker-<version>-mac-x64.dmg` |
+| Windows | `Coworker-<version>-win-x64-setup.exe` (also `arm64`) |
+| Linux | `Coworker-<version>-linux-x64.AppImage` or `.deb` |
+
+## After you download
+
+The builds are not code-signed yet, so the OS warns on first launch:
+
+- **macOS** — Open the DMG and drag Coworker to `/Applications`. Right-click the app and choose *Open*, or run
+  `xattr -dr com.apple.quarantine "/Applications/Coworker.app"`.
+- **Windows** — SmartScreen: *More info* → *Run anyway*.
+- **Linux** — `chmod +x Coworker-*.AppImage` before running it.
+
+## Publishing a release
+
+Installers are built by [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+on a matrix of macOS, Windows and Ubuntu runners, then attached to a GitHub release.
+
+```sh
+# bump "version" in package.json first
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Pushing a `v*` tag builds all three platforms and publishes the release. Re-running the
+workflow manually (**Actions → Release → Run workflow**) with an existing tag rebuilds it
+and re-uploads the assets to the same release.
+
+Nothing in the dependency tree is native — the database is `node:sqlite` — so each runner
+packages its own platform without a rebuild toolchain. Signing is not configured: add
+`CSC_LINK`/`CSC_KEY_PASSWORD` (macOS) and `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` (Windows)
+as repository secrets, and drop `identity: null` from `build.mac`, once certificates exist.

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,15 @@
+# Screenshots
+
+The [team room](../README.md) is on the main README. These are the other surfaces.
+
+**Coworkers** — each one has an independent runtime, workspace, and single focused task queue.
+
+![Coworkers](images/coworkers.png)
+
+**Chat** — streaming Markdown replies, per-coworker model switching, and the files a coworker writes into its own workspace.
+
+![Coworker chat](images/coworker-chat.png)
+
+**Approvals** — consequential actions pause here, and decisions are written to SQLite before work resumes.
+
+![Approvals](images/approvals.png)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,7 @@
+# Data and security
+
+State lives under Electron's user-data directory. Model and email API keys are encrypted with Electron `safeStorage` — plaintext keys are never written to SQLite or returned to the renderer.
+
+The renderer runs with context isolation, sandboxing, no Node integration, a restrictive CSP, and a narrow preload API. Workers cannot touch SQLite or credentials directly. File tools resolve paths against the coworker's workspace and reject traversal or escaping symlinks. Attached images are validated and capped at four images / 20 MB per message. Remote skill downloads reject credential-bearing, local, and private-network URLs, and bundled skills cannot be overwritten. There is deliberately no shell, Python, or code-execution tool.
+
+Provider, catalog, startup, inference, and runtime-exit failures are written as redacted JSON Lines to `logs/provider-errors.jsonl` in the same directory (provider/model and task/run IDs, no prompts or credentials; rotates at 5 MB). Recent entries are viewable in **Settings → Data**, where a redacted support report can be copied or exported.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The main README was carrying install matrices, feature lists, eval instructions, security notes, and the release workflow. This keeps it as a product page plus how to run the app in development.

**Main README now has:**
- The chat screenshot at the top; the rest live in [docs/screenshots.md](docs/screenshots.md)
- Moat: no subscription, runs on your computer, local models, bring your own keys, skills, scheduler, approvals, Telegram
- A link to [GitHub Releases](https://github.com/donvito/coworker/releases/latest) for per-platform installers
- The `pnpm install` / `pnpm dev` quick start

**Moved out:**
- [docs/features.md](docs/features.md) — chat, tools, skills, Telegram, platform
- [docs/development.md](docs/development.md) — scripts, evals, contributing
- [docs/security.md](docs/security.md) — data layout and hardening
- [docs/releasing.md](docs/releasing.md) — installer filenames, first-launch OS warnings, tag-and-publish

Copy for the moat section follows the product page at https://www.donvitocodes.com/coworker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04cc6-84e8-7f8f-a08b-fdd822de1f15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04cc6-84e8-7f8f-a08b-fdd822de1f15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

