### PR TITLE
docs: chat hero, Apache 2.0, README chips, and drop hidden channels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Coworker
+Copyright 2026 Melvin Vivas
+
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ AI agents for your work, running on your own computer.
 ![Linux](https://img.shields.io/badge/Linux-AppImage%20%7C%20deb-FCC624?logo=linux&logoColor=black)
 ![Local-first](https://img.shields.io/badge/local--first-yes-2ea44f)
 ![No subscription](https://img.shields.io/badge/subscription-none-2ea44f)
+![Telegram](https://img.shields.io/badge/Telegram-supported-26A5E4?logo=telegram&logoColor=white)
 
 ![Coworker chat](docs/images/coworker-chat.png)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 AI agents for your work, running on your own computer.
 
 [![Latest release](https://img.shields.io/github/v/release/donvito/coworker)](https://github.com/donvito/coworker/releases/latest)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 ![macOS](https://img.shields.io/badge/macOS-arm64%20%7C%20Intel-111111?logo=apple&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-x64%20%7C%20ARM64-0078D4?logo=windows&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-AppImage%20%7C%20deb-FCC624?logo=linux&logoColor=black)
@@ -57,3 +58,7 @@ Scripts, tests, evals, and packaging: [Development](docs/development.md)
 - [Development](docs/development.md)
 - [Data and security](docs/security.md)
 - [Releasing](docs/releasing.md)
+
+## License
+
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 AI agents for your work, running on your own computer.
 
+[![Latest release](https://img.shields.io/github/v/release/donvito/coworker)](https://github.com/donvito/coworker/releases/latest)
+![macOS](https://img.shields.io/badge/macOS-arm64%20%7C%20Intel-111111?logo=apple&logoColor=white)
+![Windows](https://img.shields.io/badge/Windows-x64%20%7C%20ARM64-0078D4?logo=windows&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-AppImage%20%7C%20deb-FCC624?logo=linux&logoColor=black)
+![Local-first](https://img.shields.io/badge/local--first-yes-2ea44f)
+![No subscription](https://img.shields.io/badge/subscription-none-2ea44f)
+
 ![Coworker chat](docs/images/coworker-chat.png)
 
 Coworker is a local-first desktop app for independent AI coworkers. There is **no subscription**. The app runs on **your computer**, talks to **local models** or keys you bring, learns new **skills**, keeps a **scheduler**, pauses on **approvals**, and can meet you on **Telegram**.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI agents for your work, running on your own computer.
 
-![Team room](docs/images/home.png)
+![Coworker chat](docs/images/coworker-chat.png)
 
 Coworker is a local-first desktop app for independent AI coworkers. There is **no subscription**. The app runs on **your computer**, talks to **local models** or keys you bring, learns new **skills**, keeps a **scheduler**, pauses on **approvals**, and can meet you on **Telegram**.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,11 +5,8 @@ Coworker is a local-first Electron app for independent AI coworkers. Each cowork
 ## Coworkers and chat
 
 - Multiple coworkers, each with its own role, system prompt, tool set, and workspace
-- Direct conversations with one coworker and shared group channels with two or more coworkers
-- Channel messages reach every member by default; typed `@mentions` narrow a request to specific coworkers
-- Channel requests involving two or more coworkers become turn-based discussions: each coworker sees the latest shared transcript, decides whether it has something to add, and passes quietly when it doesn't
-- Discussions conclude on their own when every coworker passes, with a safety check-in on unusually long discussions; reply mid-discussion to interject and steer, or stop it at any time
-- Multiple named conversations and channels persisted across restarts
+- Direct conversations with one coworker
+- Multiple named conversations persisted across restarts
 - Search conversation titles and message contents, with messages grouped and timestamped by day
 - Right-click any coworker in the chat sidebar to open their settings
 - Streaming, Markdown-rendered replies with typed tool call rendering
@@ -34,7 +31,7 @@ Coworker is a local-first Electron app for independent AI coworkers. Each cowork
 ## Skills
 
 - Agent Skills-compatible global skill library with per-coworker enablement
-- Bundled `web-search`, `document-authoring`, and `team-channel-collaboration` skills
+- Bundled `web-search` and `document-authoring` skills
 - Install by uploading a `SKILL.md`, from an HTTPS URL in Settings, or by pasting a skill URL into chat
 - Metadata is exposed to the model first; full instructions load on demand through a controlled skill reader
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,6 +1,6 @@
 # Screenshots
 
-The [chat view](../README.md) is on the main README. These are the other surfaces.
+The [chat view](../README.md) is also the hero image on the main README.
 
 **Team room** — the floor at a glance, a composer that puts any coworker to work, and a live activity log.
 
@@ -9,6 +9,10 @@ The [chat view](../README.md) is on the main README. These are the other surface
 **Coworkers** — each one has an independent runtime, workspace, and single focused task queue.
 
 ![Coworkers](images/coworkers.png)
+
+**Chat** — streaming Markdown replies, per-coworker model switching, and the files a coworker writes into its own workspace.
+
+![Coworker chat](images/coworker-chat.png)
 
 **Approvals** — consequential actions pause here, and decisions are written to SQLite before work resumes.
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,14 +1,14 @@
 # Screenshots
 
-The [team room](../README.md) is on the main README. These are the other surfaces.
+The [chat view](../README.md) is on the main README. These are the other surfaces.
+
+**Team room** — the floor at a glance, a composer that puts any coworker to work, and a live activity log.
+
+![Team room](images/home.png)
 
 **Coworkers** — each one has an independent runtime, workspace, and single focused task queue.
 
 ![Coworkers](images/coworkers.png)
-
-**Chat** — streaming Markdown replies, per-coworker model switching, and the files a coworker writes into its own workspace.
-
-![Coworker chat](images/coworker-chat.png)
 
 **Approvals** — consequential actions pause here, and decisions are written to SQLite before work resumes.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "Coworker",
   "main": "./out/main/index.js",
   "author": "Coworker",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "engines": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the slim README on `main`. This PR is ready to merge.

- Use the **chat screenshot** as the README hero, and keep it in [docs/screenshots.md](docs/screenshots.md) with team room, coworkers, and approvals
- Add README status chips: latest release, Apache 2.0, macOS / Windows / Linux, local-first, no subscription, Telegram
- License the project under **Apache License 2.0** (`LICENSE`, `NOTICE`, `package.json`)
- Drop hidden multi-coworker channels from [docs/features.md](docs/features.md) (group channels, `@mentions`, turn-based discussions, `team-channel-collaboration`)

Direct conversations and named conversation history stay in the features list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04cc6-84e8-7f8f-a08b-fdd822de1f15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04cc6-84e8-7f8f-a08b-fdd822de1f15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

